### PR TITLE
Clarify argument and its properties for request

### DIFF
--- a/browserid/index.md
+++ b/browserid/index.md
@@ -243,9 +243,9 @@ Request an identity from the user.  This will cause a dialog to be opened to pro
   * `requiredEmail` *(optional)* - An email address that the user must
     use to log in.  When provided, the user may not select a different
     address, but may cancel the sign-in.
-  * `privacyURL` - URL to site's privacy policy.  When provided, a link
+  * `privacyURL` *(optional)* - URL to site's privacy policy.  When provided, a link
     will be displayed in the sign-in dialog.
-  * `tosURL` - URL to site's terms of service.  When provided, a link will
+  * `tosURL` *(optional)* - URL to site's terms of service.  When provided, a link will
     be displayed in the sign-in dialog.
   * `oncancel` - a callback that will be invoked if the user refuses to
     share an identity with the site.


### PR DESCRIPTION
https://github.com/mozilla/id-specs/blob/dev/browserid/index.md#navigatoridrequestoptions

Is the options argument to request optional? It is not currently marked as such but none of the properties of the options are marked as required.  If it's optional this should also be indicated in the WebIDL definition. [1]

Is the oncancel property supposed to be required?  If so, it should be marked as such to be consistent with watch's required properties.

[1] http://www.w3.org/TR/WebIDL/#dfn-optional-argument
